### PR TITLE
[16.8.6] Aggressive cleanup to assist garbage collection

### DIFF
--- a/packages/react-dom/src/client/ReactDOMComponentTree.js
+++ b/packages/react-dom/src/client/ReactDOMComponentTree.js
@@ -8,11 +8,11 @@
 import {HostComponent, HostText} from 'shared/ReactWorkTags';
 import invariant from 'shared/invariant';
 
-const randomKey = Math.random()
-  .toString(36)
-  .slice(2);
-const internalInstanceKey = '__reactInternalInstance$' + randomKey;
-const internalEventHandlersKey = '__reactEventHandlers$' + randomKey;
+// const randomKey = Math.random()
+//   .toString(36)
+//   .slice(2);
+const internalInstanceKey = '__reactInternalInstance$';
+const internalEventHandlersKey = '__reactEventHandlers$';
 
 export function precacheFiberNode(hostInst, node) {
   node[internalInstanceKey] = hostInst;

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -733,6 +733,12 @@ function commitUnmount(current: Fiber): void {
       current.stateNode.__reactInternalInstance$ = null;
       break;
     }
+    case HostText: {
+      // HACK: detach fiber references from DOM
+      current.stateNode.__reactEventHandlers$ = null;
+      current.stateNode.__reactInternalInstance$ = null;
+      break;
+    }
     case HostPortal: {
       // TODO: this is recursive.
       // We are also not using this parent because

--- a/packages/react-reconciler/src/ReactFiberCommitWork.js
+++ b/packages/react-reconciler/src/ReactFiberCommitWork.js
@@ -728,6 +728,9 @@ function commitUnmount(current: Fiber): void {
     }
     case HostComponent: {
       safelyDetachRef(current);
+      // HACK: detach fiber references from DOM
+      current.stateNode.__reactEventHandlers$ = null;
+      current.stateNode.__reactInternalInstance$ = null;
       break;
     }
     case HostPortal: {


### PR DESCRIPTION
At Discord, we were experiencing serious memory leaks when upgrading to React with Fiber internals. We spent a lot of time investigating but ultimately ended on this fork to unblock us. These changes are made on top of the tagged 16.8.6 release.

If you want to try this build, you can use use `"react-dom": "discordapp/react#cfda84f6b3c49a1398709cf43b3b959366f7e01a"` to your `package.json`.

I still don't know whether the root cause of the memory leak is in userland or framework design. I do know the node-to-node pointers and fiber <-> host pointers make big memory leaks possible. See associated discussion in https://github.com/facebook/react/pull/15157.

## Changes

b0194a0
Clear the Fiber node's `nextEffect` pointers when finishing effect processing. This helps alleviate the long fiber chains that we saw in the profiler.

d28ee48
This clears the stateNode (pointer to DOM node and class instances) described above when unmounting. It appears it's easy to keep references to detached DOM nodes from leaking fiber nodes.

2e5ee2f and c31cc03
At this point, we're desperate. On unmount, I clear the host node's pointer to the Fiber node. This is most definitely a hack but with this change, we are no longer seeing memory leaks.